### PR TITLE
Add: RTK(Onpremise) is now available

### DIFF
--- a/main.go
+++ b/main.go
@@ -371,7 +371,7 @@ func main() {
 	if err := os.Unsetenv("magic_pod_api_token"); err != nil {
 		failf("Failed to remove API key data from envs, error: %s", err)
 	}
-	if err := os.Unsetenv("external_cloud_token"); err != nil {
+	if err := os.Unsetenv("external_service_token"); err != nil {
 		failf("Failed to remove external service API key data from envs, error: %s", err)
 	}
 	if err := os.Unsetenv("external_service_password"); err != nil {

--- a/main.go
+++ b/main.go
@@ -18,29 +18,32 @@ import (
 
 // Config : Configuration for this step
 type Config struct {
-	BaseURL              string          `env:"base_url,required"`
-	APIToken             stepconf.Secret `env:"magic_pod_api_token,required"`
-	OrganizationName     string          `env:"organization_name,required"`
-	ProjectName          string          `env:"project_name,required"`
-	Environment          string          `env:"environment,required"`
-	ExternalServiceToken stepconf.Secret `env:"external_service_token"`
-	OsName               string          `env:"os,required"`
-	DeviceType           string          `env:"device_type,required"`
-	Version              string          `env:"version,required"`
-	Model                string          `env:"model,required"`
-	AppType              string          `env:"app_type,required"`
-	AppPath              string          `env:"app_path"`
-	AppURL               string          `env:"app_url"`
-	BundleID             string          `env:"bundle_id"`
-	AppPackage           string          `env:"app_package"`
-	AppActivity          string          `env:"app_activity"`
-	WaitForResult        bool            `env:"wait_for_result"`
-	SendMail             string          `env:"send_mail"`
-	RetryCount           int             `env:"retry_count"`
-	CaptureType          string          `env:"capture_type,required"`
-	DeviceLanguage       string          `env:"device_language"`
-	DeviceRegion         string          `env:"device_region"`
-	MultiLangData        string          `env:"multi_lang_data"`
+	BaseURL                  string          `env:"base_url,required"`
+	APIToken                 stepconf.Secret `env:"magic_pod_api_token,required"`
+	OrganizationName         string          `env:"organization_name,required"`
+	ProjectName              string          `env:"project_name,required"`
+	Environment              string          `env:"environment,required"`
+	ExternalServiceToken     stepconf.Secret `env:"external_service_token"`
+	ExternalServiceServerURL string          `env:"external_service_server_url"`
+	ExternalServiceUserName  string          `env:"external_service_user_name"`
+	ExternalServicePassword  stepconf.Secret `env:"external_service_password"`
+	OsName                   string          `env:"os,required"`
+	DeviceType               string          `env:"device_type,required"`
+	Version                  string          `env:"version,required"`
+	Model                    string          `env:"model,required"`
+	AppType                  string          `env:"app_type,required"`
+	AppPath                  string          `env:"app_path"`
+	AppURL                   string          `env:"app_url"`
+	BundleID                 string          `env:"bundle_id"`
+	AppPackage               string          `env:"app_package"`
+	AppActivity              string          `env:"app_activity"`
+	WaitForResult            bool            `env:"wait_for_result"`
+	SendMail                 string          `env:"send_mail"`
+	RetryCount               int             `env:"retry_count"`
+	CaptureType              string          `env:"capture_type,required"`
+	DeviceLanguage           string          `env:"device_language"`
+	DeviceRegion             string          `env:"device_region"`
+	MultiLangData            string          `env:"multi_lang_data"`
 }
 
 // UploadFile : Response from upload-file API
@@ -141,8 +144,10 @@ func convertEnvironmentParam(input string) (string, error) {
 		return "magic_pod", nil
 	case "Remote TestKit":
 		return "remote_testkit", nil
+	case "Remote TestKit Onpremise":
+		return "remote_testkit_onpremise", nil
 	default:
-		return "", errors.New("Environment should be 'Magic Pod' or 'Remote TestKit'")
+		return "", errors.New("Environment should be 'Magic Pod', 'Remote TestKit' or 'Remote TestKit Onpremise'")
 	}
 }
 
@@ -240,8 +245,12 @@ func createStartBatchRunParams(cfg Config, appFileNumber int) map[string]interfa
 	params := map[string]interface{}{}
 
 	params["environment"] = cfg.Environment
-	if cfg.Environment != "magic_pod" {
+	if cfg.Environment == "remote_testkit" {
 		params["external_service_token"] = cfg.ExternalServiceToken
+	} else if cfg.Environment == "remote_testkit_onpremise" {
+		params["external_service_server_url"] = cfg.ExternalServiceServerURL
+    	params["external_service_user_name"] = cfg.ExternalServiceUserName
+		params["external_service_password"] = cfg.ExternalServicePassword
 	}
 	params["os"] = cfg.OsName
 	params["device_type"] = cfg.DeviceType
@@ -364,6 +373,9 @@ func main() {
 	}
 	if err := os.Unsetenv("external_cloud_token"); err != nil {
 		failf("Failed to remove external service API key data from envs, error: %s", err)
+	}
+	if err := os.Unsetenv("external_service_password"); err != nil {
+		failf("Failed to remove external service password key data from envs, error: %s", err)
 	}
 
 	// Upload app file if necessary

--- a/main.go
+++ b/main.go
@@ -103,6 +103,8 @@ func handleError(resp *resty.Response, err error) {
 	}
 }
 
+// Converts parameters for API call but also validates if any of parameters has a `unselectable` value from GUI(e.g. Okinawa dialect for `Device Language`).
+// We prefer not to validate parameters because it duplicates the API logic on server  
 func (cfg *Config) convertToAPIParams() []error {
 	var err error
 	errors := []error{}

--- a/step.yml
+++ b/step.yml
@@ -80,7 +80,7 @@ inputs:
       description: |-
         Environment (cloud service) on which you want to execute your tests.
         Each environment has its own limitation of OS/devices.  Please refer to project batch runs page for available choices.
-      value_options: ["Magic Pod", "Remote TestKit"]
+      value_options: ["Magic Pod", "Remote TestKit", "Remote TestKit Onpremise"]
       is_required: true
       is_expand: true
   - external_service_token: 
@@ -88,9 +88,28 @@ inputs:
       title: "External service token"
       description: |-
         Access token to use external cloud services (ex. Remote TestKit) for testing.
-        Required when you have selected **other than Magic Pod** for _Environment_.
+        Required when you have selected **Remote Testkit** for _Environment_.
       is_expand: true
       is_sensitive: true
+  - external_service_user_name: 
+    opts:
+      title: "External service user name"
+      description: |-
+        User name which is required when you select **Remote TestKit Onpremise**.
+      is_expand: true
+  - external_service_password:
+    opts:
+      title: "External service password"
+      description: |-
+        Password which is required when you select **Remote TestKit Onpremise**.
+      is_expand: true
+      is_sensitive: true
+  - external_service_server_url:
+    opts:
+      title: "External service server url"
+      description: |-
+        Server url which is required when you select **Remote TestKit Onpremise**.
+      is_expand: true
   - os: "iOS"
     opts:
       title: "OS"
@@ -108,7 +127,7 @@ inputs:
         Currently you can select only
 
         * _Simulator_ for Magic Pod cloud service.
-        * _Real Device_ for Remote TestKit.
+        * _Real Device_ for Remote TestKit and Remote TestKit Onpremise.
       is_required: true
       is_expand: true
       value_options:
@@ -131,7 +150,7 @@ inputs:
         Currently you can select only
 
         * _iPhone 8_ for Magic Pod cloud service.
-        * For Remote TestKit, please refer to model list on https://appkitbox.com/testkit/devicelist/.
+        * For Remote TestKit and Remote TestKit Onpremise, please refer to model list on https://appkitbox.com/testkit/devicelist/.
       is_required: true
       is_expand: true
   - app_type: "App file (cloud upload)"

--- a/step.yml
+++ b/step.yml
@@ -88,27 +88,27 @@ inputs:
       title: "External service token"
       description: |-
         Access token to use external cloud services (ex. Remote TestKit) for testing.
-        Required when you have selected **Remote Testkit** for _Environment_.
+        Required when you have selected __Remote Testkit__ for _Environment_.
       is_expand: true
       is_sensitive: true
   - external_service_user_name: 
     opts:
       title: "External service user name"
       description: |-
-        User name which is required when you select **Remote TestKit Onpremise**.
+        User name which is required when you select __Remote TestKit Onpremise__.
       is_expand: true
   - external_service_password:
     opts:
       title: "External service password"
       description: |-
-        Password which is required when you select **Remote TestKit Onpremise**.
+        Password which is required when you select __Remote TestKit Onpremise__.
       is_expand: true
       is_sensitive: true
   - external_service_server_url:
     opts:
       title: "External service server url"
       description: |-
-        Server url which is required when you select **Remote TestKit Onpremise**.
+        Server url which is required when you select __Remote TestKit Onpremise__.
       is_expand: true
   - os: "iOS"
     opts:

--- a/step.yml
+++ b/step.yml
@@ -88,27 +88,27 @@ inputs:
       title: "External service token"
       description: |-
         Access token to use external cloud services (ex. Remote TestKit) for testing.
-        Required when you have selected __Remote Testkit__ for _Environment_.
+        Required when you have selected _Remote Testkit_ for _Environment_.
       is_expand: true
       is_sensitive: true
   - external_service_user_name: 
     opts:
       title: "External service user name"
       description: |-
-        User name which is required when you select __Remote TestKit Onpremise__.
+        User name which is required when you select _Remote TestKit Onpremise_.
       is_expand: true
   - external_service_password:
     opts:
       title: "External service password"
       description: |-
-        Password which is required when you select __Remote TestKit Onpremise__.
+        Password which is required when you select _Remote TestKit Onpremise_.
       is_expand: true
       is_sensitive: true
   - external_service_server_url:
     opts:
       title: "External service server url"
       description: |-
-        Server url which is required when you select __Remote TestKit Onpremise__.
+        Server url which is required when you select _Remote TestKit Onpremise_.
       is_expand: true
   - os: "iOS"
     opts:


### PR DESCRIPTION
## Objectives
- https://github.com/NozomiIto/magic-pod/issues/1013

## Tests
### Did Test
- Invoke batch run for iOS locally(Bundle ID)
- UI Check
<img width="1006" alt="Screen Shot 2019-05-07 at 13 02 39" src="https://user-images.githubusercontent.com/21286384/57271234-a924a800-70c9-11e9-9692-fa80b9ccc018.png">

- Invoke batch run for Android via bitrise(App file URL)
## Related issue.
- https://github.com/NozomiIto/magic-pod/issues/1015

## Questions
1. Is this a principle which determines to do validations for input variables?
    - If a input variable needs to be converted, then the input variable needs to be validated.
    - Otherwise, a variable does not need to be validated.
2. `if err := os.Unsetenv("external_cloud_token");`on new line 374 should be actually like `if err := os.Unsetenv("external_service_token");`? It is because no such named variable in `main.go`.


