### PR TITLE
Adds iOS batch run for RTK/RTE(Onpremise) with IPA file(cloud upload/URL)

### DIFF
--- a/main.go
+++ b/main.go
@@ -251,7 +251,7 @@ func createStartBatchRunParams(cfg Config, appFileNumber int) map[string]interfa
 		params["external_service_token"] = cfg.ExternalServiceToken
 	} else if cfg.Environment == "remote_testkit_onpremise" {
 		params["external_service_server_url"] = cfg.ExternalServiceServerURL
-    	params["external_service_user_name"] = cfg.ExternalServiceUserName
+    params["external_service_user_name"] = cfg.ExternalServiceUserName
 		params["external_service_password"] = cfg.ExternalServicePassword
 	}
 	params["os"] = cfg.OsName
@@ -263,21 +263,21 @@ func createStartBatchRunParams(cfg Config, appFileNumber int) map[string]interfa
 	case "app_file":
 		params["app_file_number"] = appFileNumber
 		if cfg.OsName == "ios" {
-    	    if cfg.Environment == "remote_testkit" {
-    			params["bundle_id"] = cfg.BundleID
-    	    } else if cfg.Environment == "remote_testkit_onpremise" {
-    			params["bundle_id"] = cfg.BundleID
-    	    }
+	    if cfg.Environment == "remote_testkit" {
+        params["bundle_id"] = cfg.BundleID
+      } else if cfg.Environment == "remote_testkit_onpremise" {
+        params["bundle_id"] = cfg.BundleID
+      }
 		}
 		break
 	case "app_url":
 		params["app_url"] = cfg.AppURL
 		if cfg.OsName == "ios" {
-    	    if cfg.Environment == "remote_testkit" {
-    			params["bundle_id"] = cfg.BundleID
-    	    } else if cfg.Environment == "remote_testkit_onpremise" {
-    			params["bundle_id"] = cfg.BundleID
-    	    }
+      if cfg.Environment == "remote_testkit" {
+        params["bundle_id"] = cfg.BundleID
+      } else if cfg.Environment == "remote_testkit_onpremise" {
+        params["bundle_id"] = cfg.BundleID
+      }
 		}
 		break
 	case "installed":

--- a/main.go
+++ b/main.go
@@ -251,7 +251,7 @@ func createStartBatchRunParams(cfg Config, appFileNumber int) map[string]interfa
 		params["external_service_token"] = cfg.ExternalServiceToken
 	} else if cfg.Environment == "remote_testkit_onpremise" {
 		params["external_service_server_url"] = cfg.ExternalServiceServerURL
-    params["external_service_user_name"] = cfg.ExternalServiceUserName
+		params["external_service_user_name"] = cfg.ExternalServiceUserName
 		params["external_service_password"] = cfg.ExternalServicePassword
 	}
 	params["os"] = cfg.OsName
@@ -263,21 +263,21 @@ func createStartBatchRunParams(cfg Config, appFileNumber int) map[string]interfa
 	case "app_file":
 		params["app_file_number"] = appFileNumber
 		if cfg.OsName == "ios" {
-	    if cfg.Environment == "remote_testkit" {
-        params["bundle_id"] = cfg.BundleID
-      } else if cfg.Environment == "remote_testkit_onpremise" {
-        params["bundle_id"] = cfg.BundleID
-      }
+			if cfg.Environment == "remote_testkit" {
+				params["bundle_id"] = cfg.BundleID				
+			} else if cfg.Environment == "remote_testkit_onpremise" {
+				params["bundle_id"] = cfg.BundleID
+			}
 		}
 		break
 	case "app_url":
 		params["app_url"] = cfg.AppURL
 		if cfg.OsName == "ios" {
-      if cfg.Environment == "remote_testkit" {
-        params["bundle_id"] = cfg.BundleID
-      } else if cfg.Environment == "remote_testkit_onpremise" {
-        params["bundle_id"] = cfg.BundleID
-      }
+			if cfg.Environment == "remote_testkit" {
+				params["bundle_id"] = cfg.BundleID
+			} else if cfg.Environment == "remote_testkit_onpremise" {
+				params["bundle_id"] = cfg.BundleID
+			}
 		}
 		break
 	case "installed":

--- a/main.go
+++ b/main.go
@@ -262,9 +262,23 @@ func createStartBatchRunParams(cfg Config, appFileNumber int) map[string]interfa
 	switch cfg.AppType {
 	case "app_file":
 		params["app_file_number"] = appFileNumber
+		if cfg.OsName == "ios" {
+    	    if cfg.Environment == "remote_testkit" {
+    			params["bundle_id"] = cfg.BundleID
+    	    } else if cfg.Environment == "remote_testkit_onpremise" {
+    			params["bundle_id"] = cfg.BundleID
+    	    }
+		}
 		break
 	case "app_url":
 		params["app_url"] = cfg.AppURL
+		if cfg.OsName == "ios" {
+    	    if cfg.Environment == "remote_testkit" {
+    			params["bundle_id"] = cfg.BundleID
+    	    } else if cfg.Environment == "remote_testkit_onpremise" {
+    			params["bundle_id"] = cfg.BundleID
+    	    }
+		}
 		break
 	case "installed":
 		if cfg.OsName == "ios" {

--- a/step.yml
+++ b/step.yml
@@ -173,7 +173,7 @@ inputs:
       title: "App path"
       description: |-
         Required when you have selected _App file (cloud upload)_ for _App type_.
-        Note that _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.*
+        Note that _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.
         * *Warning: The file of the specified path is uploaded to Magic Pod cloud and can be seen by project members.*
         * For iOS simulator testing, specify the directory _xx.app_ so that included files are automatically ziped into one file before uploading. 
       is_expand: true
@@ -190,6 +190,7 @@ inputs:
       description : |-
         Specify the unique ID for the iOS app under test. 
         * ex) `com.apple.Preferences`
+
         Required when you select _iOS_ for _OS_ and one of the following conditions.
         1. When you select _Installed_ for _App type_.
         2. When you select _Remote TestKit_ for _Environment_ and _App file (URL)_ for _App type_

--- a/step.yml
+++ b/step.yml
@@ -174,7 +174,8 @@ inputs:
       description: |-
         Required when you have selected _App file (cloud upload)_ for _App type_.
         
-        * *Warning: The file of the specified path is uploaded to Magic Pod cloud and can be seen by project members.*
+        * *Warning1: _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.
+        * *Warning2: The file of the specified path is uploaded to Magic Pod cloud and can be seen by project members.*
         * For iOS simulator testing, specify the directory _xx.app_ so that included files are automatically ziped into one file before uploading. 
       is_expand: true
   - app_url:
@@ -182,12 +183,19 @@ inputs:
       title: "App URL"
       description: |-
         Required when you have selected _App file (URL)_ for _App type_.
+        
+        * *Warning: _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.
       is_expand: true
   - bundle_id: 
     opts:
       title: "Bundle ID"
       description : |-
-        Required when you have selected _iOS_ for _OS_ and _Installed_ for _App type_.
+        Required when you select _iOS_ for _OS_ and one of the following conditions.
+        1. When you select _Installed_ for _App type_.
+        2. When you select _Remote TestKit_ for _Environment_ and _App file (URL)_ for _App type_
+        3. When you select _Remote TestKit_ for _Environment_ and _App file (cloud upload)_ for _App type_
+        4. When you select _Remote TestKit Onpremise_ for _Environment_ and _App file (URL)_ for _App type_
+        5. When you select _Remote TestKit Onpremise_ for _Environment_ and _App file (cloud upload)_ for _App type_
 
         * ex) `com.apple.Preferences`
       is_expand: true

--- a/step.yml
+++ b/step.yml
@@ -88,7 +88,7 @@ inputs:
       title: "External service token"
       description: |-
         Access token to use external cloud services (ex. Remote TestKit) for testing.
-        Required when you have selected _Remote Testkit_ for _Environment_.
+        Required when you select _Remote Testkit_ for _Environment_.
       is_expand: true
       is_sensitive: true
   - external_service_user_name: 
@@ -172,7 +172,7 @@ inputs:
     opts:
       title: "App path"
       description: |-
-        Required when you have selected _App file (cloud upload)_ for _App type_.
+        Required when you select _App file (cloud upload)_ for _App type_.
         Note that _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.
         * *Warning: The file of the specified path is uploaded to Magic Pod cloud and can be seen by project members.*
         * For iOS simulator testing, specify the directory _xx.app_ so that included files are automatically ziped into one file before uploading. 
@@ -181,7 +181,7 @@ inputs:
     opts:
       title: "App URL"
       description: |-
-        Required when you have selected _App file (URL)_ for _App type_.
+        Required when you select _App file (URL)_ for _App type_.
         Note that _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.
       is_expand: true
   - bundle_id: 
@@ -199,7 +199,7 @@ inputs:
     opts:
       title: "App package"
       description: |-
-        Required when you have selected _Android_ for _OS_ and _Installed_ for _App type_.
+        Required when you select _Android_ for _OS_ and _Installed_ for _App type_.
 
         * ex) `com.android.settings`
       is_expand: true
@@ -207,7 +207,7 @@ inputs:
     opts:
       title: "App activity"
       description: |-
-        Required when you have selected _Android_ for _OS_ and _Installed_ for _App type_.
+        Required when you select _Android_ for _OS_ and _Installed_ for _App type_.
 
         * ex) `.Settings`
       is_expand: true

--- a/step.yml
+++ b/step.yml
@@ -191,12 +191,9 @@ inputs:
         Specify the unique ID for the iOS app under test. 
         * ex) `com.apple.Preferences`
 
-        This field is required when you select _iOS_ for _OS_ and one of the following conditions.
-        1. When you select _Installed_ for _App type_.
-        2. When you select _Remote TestKit_ for _Environment_ and _App file (URL)_ for _App type_
-        3. When you select _Remote TestKit_ for _Environment_ and _App file (cloud upload)_ for _App type_
-        4. When you select _Remote TestKit Onpremise_ for _Environment_ and _App file (URL)_ for _App type_
-        5. When you select _Remote TestKit Onpremise_ for _Environment_ and _App file (cloud upload)_ for _App type_
+        This field is required in one of the following conditions.
+        1. When you select _iOS_ for _OS_ and _Installed_ for _App type_.
+        2. When you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_.
       is_expand: true
   - app_package: 
     opts:

--- a/step.yml
+++ b/step.yml
@@ -173,9 +173,8 @@ inputs:
       title: "App path"
       description: |-
         Required when you have selected _App file (cloud upload)_ for _App type_.
-        
-        * *Warning1: _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.
-        * *Warning2: The file of the specified path is uploaded to Magic Pod cloud and can be seen by project members.*
+        Note that _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.*
+        * *Warning: The file of the specified path is uploaded to Magic Pod cloud and can be seen by project members.*
         * For iOS simulator testing, specify the directory _xx.app_ so that included files are automatically ziped into one file before uploading. 
       is_expand: true
   - app_url:
@@ -183,21 +182,20 @@ inputs:
       title: "App URL"
       description: |-
         Required when you have selected _App file (URL)_ for _App type_.
-        
-        * *Warning: _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.
+        Note that _Bundle ID_ is also required when you select _iOS_ for _OS_ and _Remote TestKit_ or _Remote TestKit Onpremise_ for _Environment_ due to their restriction.
       is_expand: true
   - bundle_id: 
     opts:
       title: "Bundle ID"
       description : |-
+        Specify the unique ID for the iOS app under test. 
+        * ex) `com.apple.Preferences`
         Required when you select _iOS_ for _OS_ and one of the following conditions.
         1. When you select _Installed_ for _App type_.
         2. When you select _Remote TestKit_ for _Environment_ and _App file (URL)_ for _App type_
         3. When you select _Remote TestKit_ for _Environment_ and _App file (cloud upload)_ for _App type_
         4. When you select _Remote TestKit Onpremise_ for _Environment_ and _App file (URL)_ for _App type_
         5. When you select _Remote TestKit Onpremise_ for _Environment_ and _App file (cloud upload)_ for _App type_
-
-        * ex) `com.apple.Preferences`
       is_expand: true
   - app_package: 
     opts:

--- a/step.yml
+++ b/step.yml
@@ -191,7 +191,7 @@ inputs:
         Specify the unique ID for the iOS app under test. 
         * ex) `com.apple.Preferences`
 
-        Required when you select _iOS_ for _OS_ and one of the following conditions.
+        This field is required when you select _iOS_ for _OS_ and one of the following conditions.
         1. When you select _Installed_ for _App type_.
         2. When you select _Remote TestKit_ for _Environment_ and _App file (URL)_ for _App type_
         3. When you select _Remote TestKit_ for _Environment_ and _App file (cloud upload)_ for _App type_


### PR DESCRIPTION
## Objectives
- That's it.
- Aims to resolve https://github.com/NozomiIto/magic-pod/issues/1015
- Note that when running iOS test on RTK, you have to specify bundle id besides IPA file.

## Tests
|Factor|Level|P1|P2|P3|P4|P5|P6|P7|P8|
|-|-|-|-|-|-|-|-|-|-|
|Environment|RTK|◯|◯|◯|◯|-|-|-|-|
|Environment|RTE(Onpremise)|-|-|-|-|◯|◯|◯|◯|
|Platform|iOS|◯|◯|-|-|◯|◯|-|-|
|Platform|Android|-|-|◯|◯|-|-|◯|◯|
|File|IPA(cloud upload)|◯|-|-|-|◯|-|-|-|
|File|IPA(URL)|-|◯|-|-|-|◯|-|-|
|File|APK(cloud upload)|-|-|◯|-|-|-|◯|-|
|File|APK(URL)|-|-|-|◯|-|-|-|◯|
|---|---|---|---|---|---|---|---|---|---|
|Result|OK|-|●|-|●|-|-|-|●|
|Result|`Did not check`|●|-|●|-|●|●|●|-|

- For iOS on RTE(Onpremise), it is likely that there's a problem invoking test on the provided RTE environment. So currently I can not check.
- For cloud upload, I have no idea how to test it for two reasons.
  1. cloud upload doesn't work locally.
  2. For dev environment, it needs to be authenticated.

## FYI
- This PR includes updating help messages for `App path`, `App URL` and `Bundle ID`.
- You can see how it changes as below more visually.

### App path
<img width="616" alt="Screen Shot 2019-05-09 at 12 38 09" src="https://user-images.githubusercontent.com/21286384/57425903-1fefab80-7258-11e9-88b5-f57f4067aeed.png">

### App URL
<img width="619" alt="Screen Shot 2019-05-09 at 12 38 15" src="https://user-images.githubusercontent.com/21286384/57425896-1cf4bb00-7258-11e9-920d-1d56d13f2148.png">

### Bundle ID
<img width="618" alt="Screen Shot 2019-05-09 at 12 38 45" src="https://user-images.githubusercontent.com/21286384/57425904-22ea9c00-7258-11e9-91f6-d7ef408f2b60.png">

