### PR TITLE
Add: Testing with Korean language is now available from Bitrise

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,8 +187,10 @@ func convertDeviceLanguageParam(input string) (string, error) {
 		return "en", nil
 	case "Japanese":
 		return "ja", nil
+	case "Korean":
+		return "ko", nil
 	default:
-		return "", errors.New("Device language should be 'Default', 'English' or 'Japanese'")
+		return "", errors.New("Device language should be 'Default', 'English', 'Japanese' or 'Korean'")
 	}
 }
 

--- a/step.yml
+++ b/step.yml
@@ -252,6 +252,7 @@ inputs:
         - "Default"
         - "English"
         - "Japanese"
+        - "Korean"
       is_expand: true
       category: "detail"
   - device_region: "Default"


### PR DESCRIPTION
## Objectives
- Resolves https://github.com/NozomiIto/magic-pod/issues/989
- Note that this will work after merging https://github.com/NozomiIto/magic-pod/pull/1033

## Tests
### Did Test
- Testing with Korean language and any region on iOS/Android from Bitrise